### PR TITLE
Remove redundant variable assignment

### DIFF
--- a/lib/Tie/File.pm
+++ b/lib/Tie/File.pm
@@ -170,7 +170,6 @@ sub _fetch {
     return unless defined $o;
   }
 
-  my $fh = $self->{FH};
   $self->_seek($n);             # we can do this now that offsets is populated
   my $rec = $self->_read_record;
 


### PR DESCRIPTION
This line looks like the remains of an older version.
- `$self->{FH}` does not exist.
- `$fh` is not used within that scope.
